### PR TITLE
Remove defaults for volume definitions

### DIFF
--- a/schema/v1/app.cue
+++ b/schema/v1/app.cue
@@ -168,8 +168,8 @@ package v1
 	labels:      [string]: string
 	annotations: [string]: string
 	class:       string | *""
-	size:        int | *10 | string
-	accessModes: [#AccessMode, ...#AccessMode] | #AccessMode | *"readWriteOnce"
+	size:        int | *"" | string
+	accessModes?: [#AccessMode, ...#AccessMode] | #AccessMode
 }
 
 #SecretBase: {


### PR DESCRIPTION
Now that volumes use volume classes, defaults are handled there and not in the Acornfile itself.

Related issues:
https://github.com/acorn-io/acorn/issues/1263
https://github.com/acorn-io/acorn/issues/1257