### PR TITLE
Enforce better constraints on #Metrics

### DIFF
--- a/schema/v1/app.cue
+++ b/schema/v1/app.cue
@@ -177,8 +177,8 @@ package v1
 }
 
 #Metrics: {
-	port: int
-	path: string
+	port: uint16 & >0 & <65536
+	path: =~"^/.*"
 }
 
 // Allowing [resourceType:][resourceName:][some.random/key]


### PR DESCRIPTION
for acorn-io/acorn#830

This ensures that the port specified is a valid port in the range [1,65535]. It also ensure that the path begins with `/`.